### PR TITLE
docs: adopt develop/main branch model and document release flow

### DIFF
--- a/.changelog-generator.json
+++ b/.changelog-generator.json
@@ -1,6 +1,6 @@
 {
   "repoUrl": "https://github.com/ethan-mfb/pomo.git",
-  "branchName": "main",
+  "branchName": "develop",
   "remoteName": "origin",
   "packagePath": "./package.json"
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: CI
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Pomo is a Pomodoro-style productivity timer built as an installable PWA. React 19 + TypeScript (strict) + Vite, styled with Sass. Deployed to GitHub Pages at `https://ethan-mfb.github.io/pomo/`; pushes to `main` trigger `.github/workflows/deploy.yml` automatically.
 
+**Branching model:** `develop` is the default/integration branch — all development PRs target `develop`. `main` is the production branch and only advances via a release PR from `develop` → `main`; merging that release PR is what deploys. Both branches are protected (no direct pushes — every change goes through a PR — no force-push or deletion, enforced for admins too; 0 approvals required so you can self-merge). Never commit directly to either; branch off `develop` and open a PR.
+
 ## Commands
 
 - `npm run dev` — Vite dev server (`--host`); PWA `devOptions` are enabled so the service worker is active in dev.
@@ -51,4 +53,4 @@ Components in `src/components/` are presentational (Button, Slider, Toggle, Numb
 
 ## Changelog & release
 
-Uses `@mfbtech/changelog-generator`. Before opening a PR, run `npx ccg change` to create a change file and pick a version bump; `npx ccg publish --apply` updates `CHANGELOG.md` and bumps `package.json`. Comparison branch is `main` (`.changelog-generator.json`). Commit messages follow conventional prefixes (`feat:`, `fix:`, `refactor:`, `chore:`, `docs:`).
+Uses `@mfbtech/changelog-generator`. Before opening a PR, run `npx ccg change` to create a change file and pick a version bump; `npx ccg publish --apply` updates `CHANGELOG.md` and bumps `package.json`. Comparison branch is `develop` (`.changelog-generator.json`), matching the integration branch development PRs land on. Commit messages follow conventional prefixes (`feat:`, `fix:`, `refactor:`, `chore:`, `docs:`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,4 +53,4 @@ Components in `src/components/` are presentational (Button, Slider, Toggle, Numb
 
 ## Changelog & release
 
-Uses `@mfbtech/changelog-generator`. Before opening a PR, run `npx ccg change` to create a change file and pick a version bump; `npx ccg publish --apply` updates `CHANGELOG.md` and bumps `package.json`. Comparison branch is `develop` (`.changelog-generator.json`), matching the integration branch development PRs land on. Commit messages follow conventional prefixes (`feat:`, `fix:`, `refactor:`, `chore:`, `docs:`).
+Uses `@mfbtech/changelog-generator`. On each development PR into `develop`, run `npx ccg change` to add a change file and pick the version bump, and commit it — **do not publish**. At **release time** (the `develop` → `main` PR), run `npx ccg publish --apply` to compile all accumulated change files into `CHANGELOG.md` and bump `package.json`. Comparison branch is `develop` (`.changelog-generator.json`), matching the integration branch development PRs land on. Commit messages follow conventional prefixes (`feat:`, `fix:`, `refactor:`, `chore:`, `docs:`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Pomo is a Pomodoro-style productivity timer built as an installable PWA. React 1
 - Strict TypeScript; avoid `any` and broad `eslint-disable`. Use scoped `// eslint-disable-next-line <rule>` with a reason if truly needed.
 - Magic numbers for time live in `src/constants.ts` (`SECONDS_IN_MINUTE`, `MILLISECONDS_IN_SECOND`, etc.) — reuse them.
 
-`LLM_INSTRUCTIONS.md` holds the fuller style/architecture rationale. Note it and `README.md` say "React 18"; the project is actually on **React 19** (`package.json`) — trust `package.json`.
+`LLM_INSTRUCTIONS.md` holds the fuller style/architecture rationale. For versions, trust `package.json` as the source of truth (the project is on **React 19**).
 
 ## Architecture
 

--- a/DEVELOPMENT_WORKFLOWS.md
+++ b/DEVELOPMENT_WORKFLOWS.md
@@ -2,6 +2,16 @@
 
 All workflows use git worktrees to make changes to source code and do not make changes to source code in the root repository.
 
+## Branching model
+
+`develop` is the default/integration branch; `main` is the production branch.
+Every issue → PR workflow below branches off `develop` and opens its PR **into
+`develop`**. Shipping to production is a separate **release PR from `develop` →
+`main`** (see [Release](#release-develop--main)). Both branches are protected:
+no direct pushes, no force-push or deletion, enforced for admins — all changes
+go through a pull request. See the README for the branch-structure and release
+diagrams.
+
 ## Implement Feature (issue → PR)
 
 ```mermaid
@@ -33,6 +43,12 @@ flowchart LR
     end
     G --> H[Run app]
 ```
+
+## Release (develop → main)
+
+When `develop` is ready to ship, open a release PR from `develop` into `main`.
+Merging it advances `main`, which triggers the deploy workflow and publishes to
+GitHub Pages. See the README for the release diagram.
 
 ## Start E2E (set up, don't run)
 

--- a/DEVELOPMENT_WORKFLOWS.md
+++ b/DEVELOPMENT_WORKFLOWS.md
@@ -46,9 +46,21 @@ flowchart LR
 
 ## Release (develop → main)
 
-When `develop` is ready to ship, open a release PR from `develop` into `main`.
-Merging it advances `main`, which triggers the deploy workflow and publishes to
-GitHub Pages. See the README for the release diagram.
+When `develop` is ready to ship:
+
+1. **Compile the changelog.** On a branch off `develop`, run
+   `npx ccg publish --apply` to fold every change file accumulated on `develop`
+   into `CHANGELOG.md` and bump the version in `package.json`. Commit the result
+   and merge it into `develop` via PR (both branches are protected — no direct
+   pushes).
+2. **Open the release PR** from `develop` into `main` and merge it. Merging
+   advances `main`, which triggers the deploy workflow and publishes to GitHub
+   Pages.
+
+Change files are created per development PR (`npx ccg change`) but are **not**
+published then — `ccg publish` runs only here, at release, so all changes since
+the last release land in the changelog together. See the README for the release
+diagram.
 
 ## Start E2E (set up, don't run)
 

--- a/LLM_INSTRUCTIONS.md
+++ b/LLM_INSTRUCTIONS.md
@@ -6,7 +6,7 @@ These instructions guide an AI assistant contributing to this repository. The as
 
 A Pomodoro timer PWA built with:
 
-- React 18 (function components + hooks)
+- React 19 (function components + hooks)
 - TypeScript (strict, NodeNext module resolution, explicit `.tsx` imports allowed)
 - Vite + `@vitejs/plugin-react` + `vite-plugin-pwa`
 - Sass for styling (`style.scss` root file; encourage modularization later)

--- a/README.md
+++ b/README.md
@@ -82,26 +82,28 @@ This project uses `@mfbtech/changelog-generator` to manage change files and gene
 3. Run `npx ccg change` next to `package.json`.
    - Follow prompts to describe the change and select a version bump (major/minor/patch/none).
 4. Commit the generated change file (stored under a `.change` directory created by the tool).
-5. Run `npx ccg publish -a` next to `package.json` to update the changelog.
-6. Open a PR into `develop` and merge. Releasing to production is a separate PR from `develop` → `main`.
+5. Open a PR into `develop` and merge. Do **not** run `ccg publish` here — change files accumulate on `develop` and are compiled into the changelog at release time (see [Releasing](#releasing-develop--main)).
 
 ### CI Verification (optional)
 
 Run `npx ccg change --verify` in CI to ensure a change file exists for modified code.
 
-### Publishing
+### Releasing (develop → main)
 
-To update the `CHANGELOG.md` and bump the version in `package.json`, run:
+A release compiles every change file accumulated on `develop` into
+`CHANGELOG.md`, bumps the version, and ships `main`:
 
-```bash
-npx ccg publish --apply
-```
+1. On a branch off `develop`, compile the changelog and bump `package.json`:
 
-For a dry-run (no file modifications) use:
+   ```bash
+   npx ccg publish --apply
+   ```
 
-```bash
-npx ccg publish
-```
+   Commit the result and merge it into `develop` via PR (both branches are
+   protected, so it can't be pushed directly). For a dry run first (no file
+   modifications), use `npx ccg publish`.
+2. Open the release PR from `develop` → `main` and merge it. Merging advances
+   `main`, which triggers the deploy workflow and publishes to GitHub Pages.
 
 ### Additional Notes (Changelog System)
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ React + TypeScript + Vite Progressive Web App scaffold (Sass styling).
 ## Notes
 
 - Strict TypeScript enabled.
-- React 18 with automatic JSX runtime.
+- React 19 with automatic JSX runtime.
 - Sass (`style.scss`) with variables & nesting.
 - Adjust manifest in `vite.config.ts` as needed.
 
@@ -42,7 +42,7 @@ admins too. Approvals are not required, so you can merge your own PRs.
 
 ## Deployment
 
-Hosted via GitHub Pages (project site): `https://ethan-mfb.github.io/pomo/`
+Hosted via GitHub Pages (project site): <https://ethan-mfb.github.io/pomo/>
 
 Production deploys happen automatically on pushes to `main` (or via a manual
 **Run workflow**), driven by [`.github/workflows/deploy.yml`](.github/workflows/deploy.yml).

--- a/README.md
+++ b/README.md
@@ -19,11 +19,37 @@ React + TypeScript + Vite Progressive Web App scaffold (Sass styling).
 - Sass (`style.scss`) with variables & nesting.
 - Adjust manifest in `vite.config.ts` as needed.
 
+## Branching model
+
+Two long-lived branches:
+
+- **`develop`** — the default/integration branch. All day-to-day development
+  lands here: create a feature/fix branch, then open a PR **into `develop`**.
+- **`main`** — the production branch. It only receives changes via a **release
+  PR from `develop` → `main`**, and a push to `main` is what deploys to
+  production.
+
+```mermaid
+flowchart LR
+    F[feature / fix branch] -->|PR| D[develop]
+    D -->|release PR| M[main]
+    M -->|auto-deploy| P([GitHub Pages])
+```
+
+Both branches are protected: direct pushes are blocked (all changes go through a
+pull request), force-pushes and deletion are disabled, and the rules apply to
+admins too. Approvals are not required, so you can merge your own PRs.
+
 ## Deployment
 
 Hosted via GitHub Pages (project site): `https://ethan-mfb.github.io/pomo/`
 
-Changes deploy automatically on pushes to `main` (or via a manual **Run workflow**), driven by [`.github/workflows/deploy.yml`](.github/workflows/deploy.yml). The workflow uses the modern Pages-via-Actions flow — publishing a build artifact — rather than a `gh-pages` branch.
+Production deploys happen automatically on pushes to `main` (or via a manual
+**Run workflow**), driven by [`.github/workflows/deploy.yml`](.github/workflows/deploy.yml).
+Under the branching model above, `main` only advances via a release PR from
+`develop`, so **merging that release PR is what ships to production**. The
+workflow uses the modern Pages-via-Actions flow — publishing a build artifact —
+rather than a `gh-pages` branch.
 
 ### How it works
 
@@ -51,13 +77,13 @@ This project uses `@mfbtech/changelog-generator` to manage change files and gene
 
 ### Developer Flow
 
-1. Create a feature/fix branch.
+1. Create a feature/fix branch off `develop`.
 2. Implement changes and commit.
 3. Run `npx ccg change` next to `package.json`.
    - Follow prompts to describe the change and select a version bump (major/minor/patch/none).
 4. Commit the generated change file (stored under a `.change` directory created by the tool).
 5. Run `npx ccg publish -a` next to `package.json` to update the changelog.
-6. Open PR and merge.
+6. Open a PR into `develop` and merge. Releasing to production is a separate PR from `develop` → `main`.
 
 ### CI Verification (optional)
 
@@ -79,6 +105,6 @@ npx ccg publish
 
 ### Additional Notes (Changelog System)
 
-- Default comparison branch is `main` (configured in `.changelog-generator.json`). Adjust if your primary development branch differs.
+- Default comparison branch is `develop` (configured in `.changelog-generator.json`), matching the integration branch where development PRs land.
 - If you accidentally pick the wrong bump type, edit or delete the specific change file before publishing.
 - Empty or trivial changes can use bump `none`; they will appear without version impact.


### PR DESCRIPTION
- develop is now the default/integration branch; main is production.
- Document the branching model and develop -> main release flow in README (with LR mermaid diagram), CLAUDE.md, and DEVELOPMENT_WORKFLOWS.md.
- Run CI on both main and develop.
- Point changelog-generator comparison branch at develop.