### PR TITLE
feat: add todo list (#3)

### DIFF
--- a/changes/feat-3-todo-list_2026-6-24-19-50-20.json
+++ b/changes/feat-3-todo-list_2026-6-24-19-50-20.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "pomo",
+      "comment": "Add a todo list: add, complete, delete, and reorder todos on both the config and countdown screens",
+      "type": "MINOR"
+    }
+  ]
+}

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -30,6 +30,14 @@ describe('App', () => {
     });
   }
 
+  function addTodo(text: string) {
+    const input = screen.getByLabelText(/add a todo/i);
+    fireEvent.change(input, { target: { value: text } });
+    act(() => {
+      fireEvent.submit(input.closest('form') as HTMLFormElement);
+    });
+  }
+
   it('shows the config screen with zero completed sessions on first render', () => {
     render(<App />);
 
@@ -111,6 +119,32 @@ describe('App', () => {
 
     act(() => fireEvent.click(screen.getByRole('button', { name: 'Stop Test' })));
     expect(screen.getByRole('button', { name: 'Test Alarm' })).toBeInTheDocument();
+  });
+
+  it('adds a todo on the config screen (AC1)', () => {
+    render(<App />);
+
+    addTodo('buy milk');
+
+    expect(screen.getByRole('checkbox', { name: 'buy milk' })).toBeInTheDocument();
+  });
+
+  it('keeps the todo list present and editable on the countdown screen (AC5)', () => {
+    render(<App />);
+
+    addTodo('buy milk');
+    startSessionOfMinutes(1);
+
+    // The countdown screen is showing...
+    expect(screen.getByRole('button', { name: 'Pause' })).toBeInTheDocument();
+    // ...and the todo added on the config screen is still there and modifiable.
+    expect(screen.getByRole('checkbox', { name: 'buy milk' })).toBeInTheDocument();
+
+    addTodo('write tests');
+    expect(screen.getByRole('checkbox', { name: 'write tests' })).toBeInTheDocument();
+
+    act(() => fireEvent.click(screen.getByRole('checkbox', { name: 'buy milk' })));
+    expect(screen.getByRole('checkbox', { name: 'buy milk' })).toBeChecked();
   });
 
   it('hides the volume slider and alarm test when the alarm is switched off', () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { Button } from './components/Button.tsx';
 import { ThemeToggle } from './components/ThemeToggle.tsx';
 import { Toggle } from './components/Toggle.tsx';
 import { Slider } from './components/Slider.tsx';
+import { TodoList } from './components/TodoList.tsx';
 import {
   DEFAULT_WORK_SESSION_DURATION_MINUTES,
   MILLISECONDS_IN_SECOND,
@@ -14,10 +15,12 @@ import { formatTime } from './utils.ts';
 import { useTimer } from './hooks/useTimer.ts';
 import { useAlarm } from './hooks/useAlarm.ts';
 import { useAppTheme } from './hooks/useAppTheme.ts';
+import { useTodos } from './hooks/useTodos.ts';
 import { APP_VERSION } from './version.ts';
 
 export function App() {
   const { theme, toggleTheme } = useAppTheme();
+  const { todos, addTodo, deleteTodo, toggleTodo, moveTodoUp, moveTodoDown } = useTodos();
   const [alarmEnabled, setAlarmEnabled] = useState(true);
   const [alarmVolume, setAlarmVolume] = useState(50);
   const [workSessionDurationMinutes, setWorkSessionDurationMinutes] = useState(
@@ -88,6 +91,17 @@ export function App() {
     }
   };
 
+  const todoList = (
+    <TodoList
+      todos={todos}
+      onAdd={addTodo}
+      onDelete={deleteTodo}
+      onToggle={toggleTodo}
+      onMoveUp={moveTodoUp}
+      onMoveDown={moveTodoDown}
+    />
+  );
+
   return (
     <div className="app">
       <ThemeToggle theme={theme} onToggle={toggleTheme} />
@@ -133,6 +147,7 @@ export function App() {
             onChange={setWorkSessionDurationMinutes}
           />
           <Button onClick={onStartWorkSession}>Go!</Button>
+          {todoList}
         </div>
       )}
 
@@ -151,6 +166,7 @@ export function App() {
             {isPaused ? 'Resume' : 'Pause'}
           </Button>
           <Button onClick={onCancelTimer}>Cancel</Button>
+          {todoList}
         </div>
       )}
       <p className="version">v{APP_VERSION}</p>

--- a/src/components/TodoList.scss
+++ b/src/components/TodoList.scss
@@ -1,0 +1,102 @@
+.todo-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+  text-align: left;
+
+  .todo-list-add {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+
+    label {
+      font-weight: 600;
+      color: var(--color-fg);
+      font-size: 1rem;
+    }
+
+    input[type='text'] {
+      flex: 1 1 8rem;
+      background-color: color-mix(in srgb, var(--color-fg) 10%, transparent);
+      border: 2px solid color-mix(in srgb, var(--color-fg) 20%, transparent);
+      border-radius: 4px;
+      padding: 0.5rem;
+      font-size: 1rem;
+      color: var(--color-fg);
+      transition: all 0.2s ease;
+
+      &::placeholder {
+        color: color-mix(in srgb, var(--color-fg) 50%, transparent);
+      }
+
+      &:focus {
+        outline: none;
+        border-color: var(--color-accent);
+        background-color: color-mix(in srgb, var(--color-fg) 15%, transparent);
+        box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-accent) 20%, transparent);
+      }
+
+      &:hover {
+        border-color: color-mix(in srgb, var(--color-fg) 30%, transparent);
+      }
+    }
+  }
+
+  .todo-list-items {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .todo-list-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    padding: 0.5rem;
+    border: 2px solid color-mix(in srgb, var(--color-fg) 15%, transparent);
+    border-radius: 4px;
+
+    &--completed .todo-list-item-text {
+      text-decoration: line-through;
+      color: color-mix(in srgb, var(--color-fg) 50%, transparent);
+    }
+  }
+
+  .todo-list-item-label {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex: 1 1 auto;
+    cursor: pointer;
+    color: var(--color-fg);
+
+    input[type='checkbox'] {
+      width: 1.1rem;
+      height: 1.1rem;
+      accent-color: var(--color-accent);
+      cursor: pointer;
+    }
+  }
+
+  .todo-list-item-actions {
+    display: flex;
+    gap: 0.25rem;
+    flex-shrink: 0;
+
+    .button {
+      padding: 0.25rem 0.5rem;
+      min-width: 2rem;
+
+      &:disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
+      }
+    }
+  }
+}

--- a/src/components/TodoList.scss
+++ b/src/components/TodoList.scss
@@ -90,8 +90,15 @@
     flex-shrink: 0;
 
     .button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
       padding: 0.25rem 0.5rem;
       min-width: 2rem;
+
+      svg {
+        display: block;
+      }
 
       &:disabled {
         opacity: 0.4;

--- a/src/components/TodoList.test.tsx
+++ b/src/components/TodoList.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TodoList } from './TodoList.tsx';
+import type { Todo } from '../types.ts';
+
+const todos: Todo[] = [
+  { id: '1', text: 'first', completed: false },
+  { id: '2', text: 'second', completed: true },
+  { id: '3', text: 'third', completed: false },
+];
+
+function noopProps() {
+  return {
+    todos,
+    onAdd: vi.fn(),
+    onDelete: vi.fn(),
+    onToggle: vi.fn(),
+    onMoveUp: vi.fn(),
+    onMoveDown: vi.fn(),
+  };
+}
+
+describe('TodoList', () => {
+  it('renders each todo with its completion state (AC3)', () => {
+    render(<TodoList {...noopProps()} />);
+
+    expect(screen.getByRole('checkbox', { name: 'first' })).not.toBeChecked();
+    expect(screen.getByRole('checkbox', { name: 'second' })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: 'third' })).not.toBeChecked();
+  });
+
+  it('adds a todo from the input and clears it (AC1)', async () => {
+    const props = noopProps();
+    render(<TodoList {...props} />);
+
+    const input = screen.getByLabelText(/add a todo/i);
+    await userEvent.type(input, 'buy milk');
+    await userEvent.click(screen.getByRole('button', { name: /^add$/i }));
+
+    expect(props.onAdd).toHaveBeenCalledWith('buy milk');
+    expect(input).toHaveValue('');
+  });
+
+  it('does not add a blank todo', async () => {
+    const props = noopProps();
+    render(<TodoList {...props} />);
+
+    await userEvent.type(screen.getByLabelText(/add a todo/i), '   ');
+    await userEvent.click(screen.getByRole('button', { name: /^add$/i }));
+
+    expect(props.onAdd).not.toHaveBeenCalled();
+  });
+
+  it('deletes a todo (AC2)', async () => {
+    const props = noopProps();
+    render(<TodoList {...props} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /delete first/i }));
+
+    expect(props.onDelete).toHaveBeenCalledWith('1');
+  });
+
+  it('toggles a todo (AC3)', async () => {
+    const props = noopProps();
+    render(<TodoList {...props} />);
+
+    await userEvent.click(screen.getByRole('checkbox', { name: 'first' }));
+
+    expect(props.onToggle).toHaveBeenCalledWith('1');
+  });
+
+  it('reorders todos with move up / move down, disabled at the ends (AC4)', async () => {
+    const props = noopProps();
+    render(<TodoList {...props} />);
+
+    // First item cannot move up; last item cannot move down.
+    expect(screen.getByRole('button', { name: /move first up/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /move third down/i })).toBeDisabled();
+
+    await userEvent.click(screen.getByRole('button', { name: /move second up/i }));
+    expect(props.onMoveUp).toHaveBeenCalledWith('2');
+
+    await userEvent.click(screen.getByRole('button', { name: /move second down/i }));
+    expect(props.onMoveDown).toHaveBeenCalledWith('2');
+  });
+});

--- a/src/components/TodoList.test.tsx
+++ b/src/components/TodoList.test.tsx
@@ -84,4 +84,14 @@ describe('TodoList', () => {
     await userEvent.click(screen.getByRole('button', { name: /move second down/i }));
     expect(props.onMoveDown).toHaveBeenCalledWith('2');
   });
+
+  it('renders the row action buttons with SVG icons, not text glyphs', () => {
+    render(<TodoList {...noopProps()} />);
+
+    for (const name of [/move first down/i, /delete first/i]) {
+      const button = screen.getByRole('button', { name });
+      expect(button.querySelector('svg')).toBeInTheDocument();
+      expect(button).toHaveTextContent('');
+    }
+  });
 });

--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -1,0 +1,91 @@
+import { useState } from 'react';
+import type { Todo } from '../types.ts';
+import './TodoList.scss';
+
+export type TodoListProps = {
+  todos: Todo[];
+  onAdd: (text: string) => void;
+  onDelete: (id: string) => void;
+  onToggle: (id: string) => void;
+  onMoveUp: (id: string) => void;
+  onMoveDown: (id: string) => void;
+};
+
+export function TodoList({ todos, onAdd, onDelete, onToggle, onMoveUp, onMoveDown }: TodoListProps) {
+  const [draft, setDraft] = useState('');
+
+  const submitDraft = (event: React.FormEvent) => {
+    event.preventDefault();
+    const trimmed = draft.trim();
+    if (trimmed === '') {
+      return;
+    }
+    onAdd(trimmed);
+    setDraft('');
+  };
+
+  return (
+    <section className="todo-list">
+      <form className="todo-list-add" onSubmit={submitDraft}>
+        <label htmlFor="todo-input">Add a todo</label>{' '}
+        <input
+          id="todo-input"
+          name="todo-input"
+          type="text"
+          value={draft}
+          placeholder="What needs doing?"
+          onChange={(e) => setDraft(e.target.value)}
+        />
+        <button className="button" type="submit">
+          Add
+        </button>
+      </form>
+
+      <ul className="todo-list-items">
+        {todos.map((todo, index) => (
+          <li
+            key={todo.id}
+            className={`todo-list-item ${todo.completed ? 'todo-list-item--completed' : ''}`}
+          >
+            <label className="todo-list-item-label">
+              <input
+                type="checkbox"
+                checked={todo.completed}
+                onChange={() => onToggle(todo.id)}
+              />
+              <span className="todo-list-item-text">{todo.text}</span>
+            </label>
+            <div className="todo-list-item-actions">
+              <button
+                className="button"
+                type="button"
+                aria-label={`Move ${todo.text} up`}
+                disabled={index === 0}
+                onClick={() => onMoveUp(todo.id)}
+              >
+                ↑
+              </button>
+              <button
+                className="button"
+                type="button"
+                aria-label={`Move ${todo.text} down`}
+                disabled={index === todos.length - 1}
+                onClick={() => onMoveDown(todo.id)}
+              >
+                ↓
+              </button>
+              <button
+                className="button"
+                type="button"
+                aria-label={`Delete ${todo.text}`}
+                onClick={() => onDelete(todo.id)}
+              >
+                ✕
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -2,6 +2,46 @@ import { useState } from 'react';
 import type { Todo } from '../types.ts';
 import './TodoList.scss';
 
+// Presentational icons for the row action buttons. Each button carries its own
+// aria-label, so the SVGs are decorative (aria-hidden) and inherit the button's
+// text color via `currentColor`.
+const iconProps = {
+  width: 16,
+  height: 16,
+  viewBox: '0 0 16 16',
+  fill: 'none',
+  stroke: 'currentColor',
+  strokeWidth: 2,
+  strokeLinecap: 'round' as const,
+  strokeLinejoin: 'round' as const,
+  'aria-hidden': true,
+  focusable: false,
+};
+
+function ChevronUpIcon() {
+  return (
+    <svg {...iconProps}>
+      <path d="M4 10l4-4 4 4" />
+    </svg>
+  );
+}
+
+function ChevronDownIcon() {
+  return (
+    <svg {...iconProps}>
+      <path d="M4 6l4 4 4-4" />
+    </svg>
+  );
+}
+
+function CloseIcon() {
+  return (
+    <svg {...iconProps}>
+      <path d="M4 4l8 8M12 4l-8 8" />
+    </svg>
+  );
+}
+
 export type TodoListProps = {
   todos: Todo[];
   onAdd: (text: string) => void;
@@ -63,7 +103,7 @@ export function TodoList({ todos, onAdd, onDelete, onToggle, onMoveUp, onMoveDow
                 disabled={index === 0}
                 onClick={() => onMoveUp(todo.id)}
               >
-                ↑
+                <ChevronUpIcon />
               </button>
               <button
                 className="button"
@@ -72,7 +112,7 @@ export function TodoList({ todos, onAdd, onDelete, onToggle, onMoveUp, onMoveDow
                 disabled={index === todos.length - 1}
                 onClick={() => onMoveDown(todo.id)}
               >
-                ↓
+                <ChevronDownIcon />
               </button>
               <button
                 className="button"
@@ -80,7 +120,7 @@ export function TodoList({ todos, onAdd, onDelete, onToggle, onMoveUp, onMoveDow
                 aria-label={`Delete ${todo.text}`}
                 onClick={() => onDelete(todo.id)}
               >
-                ✕
+                <CloseIcon />
               </button>
             </div>
           </li>

--- a/src/hooks/useTodos.test.ts
+++ b/src/hooks/useTodos.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useTodos } from './useTodos.ts';
+
+describe('useTodos', () => {
+  it('starts with an empty list', () => {
+    const { result } = renderHook(() => useTodos());
+    expect(result.current.todos).toEqual([]);
+  });
+
+  it('adds a todo with trimmed text, not completed (AC1)', () => {
+    const { result } = renderHook(() => useTodos());
+
+    act(() => result.current.addTodo('  buy milk  '));
+
+    expect(result.current.todos).toHaveLength(1);
+    expect(result.current.todos[0]).toMatchObject({ text: 'buy milk', completed: false });
+    expect(result.current.todos[0].id).toEqual(expect.any(String));
+  });
+
+  it('ignores empty or whitespace-only todos', () => {
+    const { result } = renderHook(() => useTodos());
+
+    act(() => result.current.addTodo('   '));
+    act(() => result.current.addTodo(''));
+
+    expect(result.current.todos).toEqual([]);
+  });
+
+  it('gives each todo a distinct id', () => {
+    const { result } = renderHook(() => useTodos());
+
+    act(() => result.current.addTodo('a'));
+    act(() => result.current.addTodo('b'));
+
+    const [first, second] = result.current.todos;
+    expect(first.id).not.toEqual(second.id);
+  });
+
+  it('deletes a todo by id (AC2)', () => {
+    const { result } = renderHook(() => useTodos());
+    act(() => result.current.addTodo('a'));
+    act(() => result.current.addTodo('b'));
+    const idToDelete = result.current.todos[0].id;
+
+    act(() => result.current.deleteTodo(idToDelete));
+
+    expect(result.current.todos).toHaveLength(1);
+    expect(result.current.todos[0].text).toBe('b');
+  });
+
+  it('toggles a todo between complete and incomplete (AC3)', () => {
+    const { result } = renderHook(() => useTodos());
+    act(() => result.current.addTodo('a'));
+    const id = result.current.todos[0].id;
+
+    act(() => result.current.toggleTodo(id));
+    expect(result.current.todos[0].completed).toBe(true);
+
+    act(() => result.current.toggleTodo(id));
+    expect(result.current.todos[0].completed).toBe(false);
+  });
+
+  it('moves a todo up, and is a no-op for the first item (AC4)', () => {
+    const { result } = renderHook(() => useTodos());
+    act(() => result.current.addTodo('a'));
+    act(() => result.current.addTodo('b'));
+    act(() => result.current.addTodo('c'));
+
+    const bId = result.current.todos[1].id;
+    act(() => result.current.moveTodoUp(bId));
+    expect(result.current.todos.map((t) => t.text)).toEqual(['b', 'a', 'c']);
+
+    // Now 'b' is first; moving it up again does nothing.
+    act(() => result.current.moveTodoUp(bId));
+    expect(result.current.todos.map((t) => t.text)).toEqual(['b', 'a', 'c']);
+  });
+
+  it('moves a todo down, and is a no-op for the last item (AC4)', () => {
+    const { result } = renderHook(() => useTodos());
+    act(() => result.current.addTodo('a'));
+    act(() => result.current.addTodo('b'));
+    act(() => result.current.addTodo('c'));
+
+    const bId = result.current.todos[1].id;
+    act(() => result.current.moveTodoDown(bId));
+    expect(result.current.todos.map((t) => t.text)).toEqual(['a', 'c', 'b']);
+
+    // Now 'b' is last; moving it down again does nothing.
+    act(() => result.current.moveTodoDown(bId));
+    expect(result.current.todos.map((t) => t.text)).toEqual(['a', 'c', 'b']);
+  });
+});

--- a/src/hooks/useTodos.ts
+++ b/src/hooks/useTodos.ts
@@ -1,0 +1,55 @@
+import { useCallback, useState } from 'react';
+import type { Todo } from '../types.ts';
+
+/**
+ * Owns the todo list and the operations over it. Kept as a hook (rather than
+ * inline `App` state) so the list logic stays testable in isolation, matching
+ * the engine-in-hooks pattern used by `useTimer`/`useAlarm`.
+ */
+export function useTodos(): {
+  todos: Todo[];
+  addTodo: (text: string) => void;
+  deleteTodo: (id: string) => void;
+  toggleTodo: (id: string) => void;
+  moveTodoUp: (id: string) => void;
+  moveTodoDown: (id: string) => void;
+} {
+  const [todos, setTodos] = useState<Todo[]>([]);
+
+  const addTodo = useCallback((text: string) => {
+    const trimmed = text.trim();
+    if (trimmed === '') {
+      return;
+    }
+    setTodos((prev) => [...prev, { id: crypto.randomUUID(), text: trimmed, completed: false }]);
+  }, []);
+
+  const deleteTodo = useCallback((id: string) => {
+    setTodos((prev) => prev.filter((todo) => todo.id !== id));
+  }, []);
+
+  const toggleTodo = useCallback((id: string) => {
+    setTodos((prev) =>
+      prev.map((todo) => (todo.id === id ? { ...todo, completed: !todo.completed } : todo))
+    );
+  }, []);
+
+  // Swap the todo at `index` with the one at `index + offset`, if in range.
+  const move = useCallback((id: string, offset: number) => {
+    setTodos((prev) => {
+      const index = prev.findIndex((todo) => todo.id === id);
+      const target = index + offset;
+      if (index === -1 || target < 0 || target >= prev.length) {
+        return prev;
+      }
+      const next = [...prev];
+      [next[index], next[target]] = [next[target], next[index]];
+      return next;
+    });
+  }, []);
+
+  const moveTodoUp = useCallback((id: string) => move(id, -1), [move]);
+  const moveTodoDown = useCallback((id: string) => move(id, 1), [move]);
+
+  return { todos, addTodo, deleteTodo, toggleTodo, moveTodoUp, moveTodoDown };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,16 @@ import { THEMES } from './constants.ts';
 
 export type Theme = (typeof THEMES)[keyof typeof THEMES];
 
+// A single item in the todo list.
+export type Todo = {
+  /** Stable unique identifier. */
+  id: string;
+  /** Display text (trimmed on entry). */
+  text: string;
+  /** True once the user has marked it done. */
+  completed: boolean;
+};
+
 // Represents parameters needed to start a work/break session.
 export type SessionState = {
   /** Total duration (seconds) of the session. */


### PR DESCRIPTION
## Summary

Adds a todo list to Pomo, available on **both** the config (main) screen and the countdown screen. Todos can be added, completed, deleted, and reordered.

Closes #3

## Design

Follows the repo's engine-in-hooks pattern:

- **`src/hooks/useTodos.ts`** — owns the `Todo[]` state and all operations (`addTodo`, `deleteTodo`, `toggleTodo`, `moveTodoUp`, `moveTodoDown`). IDs via `crypto.randomUUID()`; blank/whitespace entries are ignored and text is trimmed.
- **`src/components/TodoList.tsx`** (+ `.scss`) — presentational: an add form (local draft state), and per-row a completion checkbox, ↑/↓ reorder buttons (disabled at the ends), and a delete button. Styled with the existing `--color-*` SCSS variables.
- **`src/App.tsx`** — calls `useTodos()` and renders one shared `<TodoList>` in both the config block and the countdown block, so the same list is editable in both places.
- **`src/types.ts`** — new `Todo` type alias.

Reorder uses ↑/↓ buttons (confirmed with the requester) rather than drag-and-drop — accessible, testable, and no new dependency. No dependencies were added.

## Acceptance criteria

| # | Criterion | How it's satisfied | Verified by |
|---|-----------|--------------------|-------------|
| 1 | Add a todo on the main page | Add form on the config screen → `addTodo` | `useTodos.test.ts` (add/trim/ignore-blank), `TodoList.test.tsx` (add + clears input), `App.test.tsx` "adds a todo on the config screen (AC1)" |
| 2 | Delete a todo | Per-row delete button → `deleteTodo` | `useTodos.test.ts`, `TodoList.test.tsx` |
| 3 | Complete a todo | Per-row checkbox → `toggleTodo`, strike-through styling | `useTodos.test.ts`, `TodoList.test.tsx` |
| 4 | Re-order a todo | ↑/↓ buttons → `moveTodoUp`/`moveTodoDown`, disabled at ends | `useTodos.test.ts` (move up/down + no-op at ends), `TodoList.test.tsx` (buttons + disabled state) |
| 5 | Modify the todo list on the countdown page | Same `<TodoList>` rendered in the countdown block | `App.test.tsx` "keeps the todo list present and editable on the countdown screen (AC5)" |

## Verification

- `npm run lint` — clean
- `npm run build` — passes (type check gates the build)
- `npm test` — **65/65 passing** (14 files), including the new `useTodos`, `TodoList`, and `App` integration tests

A changelog change file (MINOR bump) was added via `ccg change` and is not published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
